### PR TITLE
Background image

### DIFF
--- a/pelican/themes/notmyidea/static/css/main.css
+++ b/pelican/themes/notmyidea/static/css/main.css
@@ -17,7 +17,12 @@
 /***** Global *****/
 /* Body */
 body {
-    background: #F5F4EF;
+    background-color: #F5F4EF;
+    background-image: url('/images/2007/01/100_0234.jpg');
+    background-repeat: no-repeat;
+    background-size: 80%;
+    background-position: center top;
+    background-attachment: fixed;
     color: #000305;
     font-size: 87.5%; /* Base font size: 14px */
     font-family: 'Trebuchet MS', Trebuchet, 'Lucida Sans Unicode', 'Lucida Grande', 'Lucida Sans', Arial, sans-serif;


### PR DESCRIPTION
Get that old felling of the road back to the theme content.

The background-size at 80% may bring some issues to the mobile version of the site.
